### PR TITLE
Fix error caused by 'fastboot getvar token' returning 'GetVar Variabl…

### DIFF
--- a/src/main/java/com/xiaomitool/v2/adb/AdbUtils.java
+++ b/src/main/java/com/xiaomitool/v2/adb/AdbUtils.java
@@ -129,6 +129,22 @@ public class AdbUtils {
         return m.group(1).trim();
     }
 
+    public static String parseOemToken(String output) {
+        if (output == null) {
+            return null;
+        }
+        Pattern pattern = Pattern.compile("\\s*" + "token" + "\\s*:\\s*([^\\n]+)");
+        Matcher m = pattern.matcher(output);
+        if (!m.find()) {
+            return null;
+        }
+        String first =  m.group(1).trim();
+        if (!m.find()) {
+            return first;
+        }
+        return first + m.group(1).trim();
+    }
+
     public static String parseFastbootOemInfo(List<String> output) {
         Pattern pattern = Pattern.compile("Device unlocked:\\s*(\\w+)", Pattern.CASE_INSENSITIVE);
         for (String line : output) {

--- a/src/main/java/com/xiaomitool/v2/adb/FastbootCommons.java
+++ b/src/main/java/com/xiaomitool/v2/adb/FastbootCommons.java
@@ -73,6 +73,15 @@ public class FastbootCommons {
         return command_list("devices");
     }
 
+    public static String getUnlockToken(String device) {
+        String token = getvar("token", device);
+        if (token != null) {
+            return token;
+        } else {
+            return oemGetToken(device);
+        }
+    }
+
     public static List<String> getvars(String device) {
         FastbootRunner runner = command_fast("getvar all", device, DEFAULT_TIMEOUT);
         if (runner == null) {
@@ -93,6 +102,17 @@ public class FastbootCommons {
             return "";
         }
         return AdbUtils.parseFastbootVar(var, runner.getOutputString());
+    }
+
+    public static String oemGetToken(String device) {
+        FastbootRunner runner = command_fast("oem get_token", device, DEFAULT_TIMEOUT);
+        if (runner == null) {
+            return null;
+        }
+        if (runner.getExitValue() != 0) {
+            return "";
+        }
+        return AdbUtils.parseOemToken(runner.getOutputString());
     }
 
     public static List<String> oemDeviceInfo(String device) {

--- a/src/main/java/com/xiaomitool/v2/procedure/install/FastbootInstall.java
+++ b/src/main/java/com/xiaomitool/v2/procedure/install/FastbootInstall.java
@@ -231,7 +231,7 @@ public class FastbootInstall {
                         throw new InstallException("Login is required for this action. Please login with your Xiaomi account", InstallException.Code.INFO_RETRIVE_FAILED);
                     }
                 }
-                String token = FastbootCommons.getvar("token", device.getSerial());
+                String token = FastbootCommons.getUnlockToken(device.getSerial());
                 Thread.sleep(400);
                 if (token == null) {
                     throw new InstallException("Failed to get the device unlock token", InstallException.Code.INFO_RETRIVE_FAILED, FastbootCommons.getLastError(device.getSerial()));
@@ -274,7 +274,7 @@ public class FastbootInstall {
                 }
                 Log.info("Unlock request confirmation success");
                 while (true) {
-                    token = FastbootCommons.getvar("token", device.getSerial());
+                    token = FastbootCommons.getUnlockToken(device.getSerial());
                     if (token == null) {
                         throw new InstallException("Failed to get the device unlock token", InstallException.Code.INFO_RETRIVE_FAILED, FastbootCommons.getLastError(device.getSerial()));
                     }


### PR DESCRIPTION
…e Not found' on newer devices when unlocking bootloader.